### PR TITLE
Chat UI Improvements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -42,6 +42,8 @@
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
 }
 
 :root {
@@ -62,7 +64,10 @@
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
+  --success: oklch(0.627 0.265 149.213);
+  --success-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
+
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
   --chart-1: oklch(0.646 0.222 41.116);
@@ -113,6 +118,8 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --success: oklch(0.627 0.265 149.213);
+  --success-foreground: oklch(0.985 0 0);
 }
 
 @layer base {

--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -11,8 +11,7 @@ import { MODELS } from "@/constants/models";
 import { Bot, Command, User } from "lucide-react";
 import { useMemo, useState } from "react";
 import { MarkdownRenderer } from "./markdown-renderer";
-import { ToolCallDisplay } from "./message/tool-call-display";
-import { ThinkingDisplay } from "./message/thinking-display";
+import { ResponseTimeline } from "./message/response-timeline";
 import { MessageActions } from "./message/message-actions";
 import { parseMessageMetadata } from "@/lib/chat/parse-message-metadata";
 import { AttachmentGallery } from "./message/attachment-gallery";
@@ -147,20 +146,18 @@ export function MessageBubble({
 
       <div className="flex-1 overflow-hidden">
         <div className="text-sm">
-          <ThinkingDisplay
-            reasoning={reasoning ?? ""}
-            isStreaming={!isUser && isStreamingReasoning}
-            initialOpen={isLatest && !!reasoning}
-          />
-
-          {toolData && (
-            <ToolCallDisplay
-              toolCalls={toolData.toolCalls}
-              toolResults={toolData.toolResults}
+          {!isUser && (
+            <ResponseTimeline
+              reasoning={reasoning}
+              isStreamingReasoning={isStreamingReasoning}
+              toolCalls={toolData?.toolCalls}
+              toolResults={toolData?.toolResults}
+              isLatest={isLatest}
             />
           )}
 
           {isUser && message.attachments && message.attachments.length > 0 && (
+
             <AttachmentGallery attachments={message.attachments} />
           )}
           {isUser ? (

--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -157,7 +157,6 @@ export function MessageBubble({
           )}
 
           {isUser && message.attachments && message.attachments.length > 0 && (
-
             <AttachmentGallery attachments={message.attachments} />
           )}
           {isUser ? (
@@ -206,9 +205,11 @@ export function MessageBubble({
                   servers={mcpServers.filter((s) => s.enabled)}
                 />
               ) : (
-                <div className="whitespace-pre-wrap">
-                  {promptMeta ? promptMeta.userContent : message.content}
-                </div>
+                <MarkdownRenderer
+                  content={
+                    promptMeta ? promptMeta.userContent : message.content
+                  }
+                />
               )}
             </div>
           ) : (

--- a/components/chat/message/response-timeline.tsx
+++ b/components/chat/message/response-timeline.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { ToolCall, ToolResult } from "@/lib/chat/parse-message-metadata";
+import { ThinkingDisplay } from "./thinking-display";
+import { ToolCallDisplay } from "./tool-call-display";
+import { useMemo } from "react";
+
+interface ResponseTimelineProps {
+  reasoning?: string;
+  isStreamingReasoning?: boolean;
+  toolCalls?: ToolCall[];
+  toolResults?: ToolResult[];
+  isLatest?: boolean;
+}
+
+export function ResponseTimeline({
+  reasoning,
+  isStreamingReasoning,
+  toolCalls,
+  toolResults,
+  isLatest,
+}: ResponseTimelineProps) {
+  // Currently, we don't have true interleaving from the backend yet,
+  // so we'll group them: Thinking first, then Tool Calls.
+  // This structure allows us to easily add interleaved support later if the backend emits sequential steps.
+  
+  const steps = useMemo(() => {
+    const items: React.ReactNode[] = [];
+    let stepCount = 0;
+
+    // 1. Thinking Step
+    if (reasoning || isStreamingReasoning) {
+      stepCount++;
+      items.push(
+        <ThinkingDisplay
+          key="thinking"
+          reasoning={reasoning ?? ""}
+          isStreaming={isStreamingReasoning}
+          initialOpen={isLatest && !!reasoning}
+          stepNumber={stepCount}
+        />
+      );
+    }
+
+    // 2. Tool Calls Step
+    if (toolCalls && toolCalls.length > 0) {
+      items.push(
+        <ToolCallDisplay
+          key="tools"
+          toolCalls={toolCalls}
+          toolResults={toolResults ?? []}
+        />
+      );
+    }
+
+    return items;
+  }, [reasoning, isStreamingReasoning, toolCalls, toolResults, isLatest]);
+
+  if (steps.length === 0) return null;
+
+  return <div className="space-y-2">{steps}</div>;
+}

--- a/components/chat/message/thinking-display.tsx
+++ b/components/chat/message/thinking-display.tsx
@@ -5,50 +5,76 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { Brain, ChevronDown } from "lucide-react";
+import { Brain, ChevronDown, Loader2 } from "lucide-react";
 import { MarkdownRenderer } from "../markdown-renderer";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { cn } from "@/lib/utils";
 
 interface ThinkingDisplayProps {
   reasoning: string;
   isStreaming?: boolean;
   initialOpen?: boolean;
+  stepNumber?: number;
 }
 
 export function ThinkingDisplay({
   reasoning,
   isStreaming,
   initialOpen = false,
+  stepNumber,
 }: ThinkingDisplayProps) {
-  const [isOpen, setIsOpen] = useState(initialOpen);
+  const [isOpen, setIsOpen] = useState(initialOpen || !!isStreaming);
+  const [hasOpenedFromStreaming, setHasOpenedFromStreaming] = useState(false);
 
-  if (isStreaming) {
-    return (
-      <div className="flex items-center gap-2 text-sm text-muted-foreground animate-pulse mb-2">
-        <Brain className="size-4" />
-        <span>Thinking...</span>
-      </div>
-    );
+  // Auto-open once when streaming starts
+  if (isStreaming && !isOpen && !hasOpenedFromStreaming) {
+    setIsOpen(true);
+    setHasOpenedFromStreaming(true);
   }
 
-  if (!reasoning) return null;
+  if (!reasoning && !isStreaming) return null;
 
   return (
-    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground mb-2 w-full">
-        <Brain className="size-4" />
-        <span>Thought process</span>
-        <ChevronDown
-          className={`size-3 ml-auto transition-transform ${
-            isOpen ? "rotate-180" : ""
-          }`}
-        />
-      </CollapsibleTrigger>
-      <CollapsibleContent>
-        <div className="text-xs text-muted-foreground mb-2">
-          <MarkdownRenderer content={reasoning} />
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
+    <div className="mb-3">
+      <Collapsible
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        className="w-full rounded-lg border border-muted bg-muted/20 overflow-hidden"
+      >
+        <CollapsibleTrigger
+          className={cn(
+            "flex items-center gap-2 p-3 w-full text-sm font-medium transition-colors hover:bg-muted/30 outline-none",
+            isOpen ? "border-b border-muted" : ""
+          )}
+        >
+          <div className="flex items-center gap-2 flex-1 text-muted-foreground">
+            {isStreaming ? (
+              <Loader2 className="size-4 animate-spin text-primary" />
+            ) : (
+              <Brain className="size-4" />
+            )}
+            <span className="text-xs uppercase tracking-wider font-semibold">
+              {stepNumber ? `Step ${stepNumber}: ` : ""}
+              {isStreaming ? "Thinking..." : "Thought process"}
+            </span>
+          </div>
+          <ChevronDown
+            className={cn(
+              "size-4 text-muted-foreground transition-transform duration-200",
+              isOpen ? "rotate-180" : ""
+            )}
+          />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="p-4 text-sm text-muted-foreground/90 bg-muted/10 leading-relaxed max-h-[500px] overflow-y-auto custom-scrollbar">
+            <MarkdownRenderer content={reasoning} />
+            {isStreaming && (
+              <span className="inline-block w-1.5 h-4 ml-1 bg-primary/40 animate-pulse align-middle" />
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
   );
 }
+

--- a/components/chat/message/tool-call-display.tsx
+++ b/components/chat/message/tool-call-display.tsx
@@ -5,7 +5,8 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { ChevronRight, Wrench } from "lucide-react";
+import { ChevronDown, Terminal, CheckCircle2, XCircle, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 type ToolCall = {
   toolCallId: string;
@@ -36,36 +37,90 @@ export function ToolCallDisplay({
         const result = toolResults.find(
           (tr) => tr.toolCallId === tc.toolCallId,
         );
+        const isCompleted = !!result;
+        const isError = isCompleted && (result.result as any)?.error;
+        
         return (
-          <Collapsible key={tc.toolCallId}>
-            <CollapsibleTrigger className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer">
-              <Wrench className="h-3.5 w-3.5" />
-              <span>
-                Used <strong>{tc.toolName}</strong>
-              </span>
-              <ChevronRight className="h-3.5 w-3.5 transition-transform [[data-state=open]>&]:rotate-90" />
-            </CollapsibleTrigger>
-            <CollapsibleContent className="mt-1 ml-5 text-xs">
-              <div className="rounded-lg bg-muted p-2 font-mono">
-                <p className="font-semibold mb-1">Input:</p>
-                <pre className="whitespace-pre-wrap">
-                  {JSON.stringify(tc.args, null, 2)}
-                </pre>
-                {result && (
-                  <>
-                    <p className="font-semibold mt-2 mb-1">Output:</p>
-                    <pre className="whitespace-pre-wrap max-h-40 overflow-y-auto">
-                      {typeof result.result === "string"
-                        ? result.result
-                        : JSON.stringify(result.result, null, 2)}
-                    </pre>
-                  </>
-                )}
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
+          <div key={tc.toolCallId} className="group/tool">
+            <Collapsible className="w-full rounded-lg border border-muted bg-muted/20 overflow-hidden">
+              <CollapsibleTrigger className="flex items-center gap-2 p-2.5 w-full text-sm font-medium transition-colors hover:bg-muted/30 outline-none">
+                <div className="flex items-center gap-2 flex-1 text-muted-foreground">
+                  <div className="relative">
+                    <Terminal className="size-4" />
+                    {!isCompleted && (
+                      <div className="absolute -top-1 -right-1">
+                        <Loader2 className="size-2 animate-spin text-primary" />
+                      </div>
+                    )}
+                  </div>
+                  <span className="text-xs font-mono">
+                    {tc.toolName}
+                  </span>
+                  {isCompleted && (
+                    <div className="flex items-center gap-1.5 ml-2">
+                      {isError ? (
+                        <XCircle className="size-3.5 text-destructive" />
+                      ) : (
+                        <CheckCircle2 className="size-3.5 text-success" />
+                      )}
+                      <span className={cn(
+                        "text-[10px] uppercase font-bold",
+                        isError ? "text-destructive" : "text-success"
+                      )}>
+                        {isError ? "Failed" : "Success"}
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <ChevronDown className="size-4 text-muted-foreground transition-transform duration-200 [[data-state=open]>&]:rotate-180" />
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="p-3 pt-0 border-t border-muted bg-muted/5">
+                  <div className="mt-2 space-y-3">
+                    <div>
+                      <div className="flex items-center gap-2 mb-1.5">
+                        <span className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">Arguments</span>
+                        <div className="h-px flex-1 bg-muted" />
+                      </div>
+                      <div className="max-h-60 overflow-y-auto overflow-x-hidden rounded-md bg-zinc-950/90 dark:bg-black/40 ring-1 ring-inset ring-white/5">
+                        <div className="p-2.5">
+                          <pre className="text-[11px] font-mono leading-relaxed text-zinc-300 whitespace-pre-wrap break-all">
+                            {JSON.stringify(tc.args, null, 2)}
+                          </pre>
+                        </div>
+                      </div>
+                    </div>
+
+                    {isCompleted && (
+                      <div>
+                        <div className="flex items-center gap-2 mb-1.5">
+                          <span className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">Result</span>
+                          <div className="h-px flex-1 bg-muted" />
+                        </div>
+                        <div className={cn(
+                          "max-h-80 overflow-y-auto overflow-x-hidden rounded-md ring-1 ring-inset",
+                          isError 
+                            ? "bg-destructive/5 text-destructive ring-destructive/20" 
+                            : "bg-zinc-950/90 dark:bg-black/40 text-zinc-300 ring-white/5"
+                        )}>
+                          <div className="p-2.5">
+                            <pre className="text-[11px] font-mono leading-relaxed whitespace-pre-wrap break-all">
+                              {typeof result.result === "string"
+                                ? result.result
+                                : JSON.stringify(result.result, null, 2)}
+                            </pre>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
         );
       })}
     </div>
   );
 }
+

--- a/lib/chat/parse-message-metadata.ts
+++ b/lib/chat/parse-message-metadata.ts
@@ -1,10 +1,10 @@
-type ToolCall = {
+export type ToolCall = {
   toolCallId: string;
   toolName: string;
   args: unknown;
 };
 
-type ToolResult = {
+export type ToolResult = {
   toolCallId: string;
   toolName: string;
   result: unknown;


### PR DESCRIPTION
This pull request introduces a more structured and visually informative way to display assistant responses in chat, particularly around step-by-step reasoning and tool usage. It adds a new `ResponseTimeline` component to group and present the assistant's "thinking" process and tool calls, and enhances the UI for both. Additionally, it introduces new CSS variables for success states and updates the tool call display to clearly indicate success or failure.

**Improvements to assistant response display:**

- Added a new `ResponseTimeline` component that groups the assistant's reasoning ("thinking") and tool call steps, making the response easier to follow and paving the way for future interleaved step support. (`components/chat/message/response-timeline.tsx`)
- Updated `MessageBubble` to use the new `ResponseTimeline`, replacing the previous `ThinkingDisplay` and `ToolCallDisplay` usage, and switched user message rendering to use `MarkdownRenderer` for consistency. (`components/chat/message-bubble.tsx`) [[1]](diffhunk://#diff-8f5465fdf09c498ad4e97658d565eb6f51698d32382844c2679e0a349a3bc623L14-R14) [[2]](diffhunk://#diff-8f5465fdf09c498ad4e97658d565eb6f51698d32382844c2679e0a349a3bc623L150-R155) [[3]](diffhunk://#diff-8f5465fdf09c498ad4e97658d565eb6f51698d32382844c2679e0a349a3bc623L212-R212)

**UI/UX enhancements for reasoning and tool calls:**

- Improved `ThinkingDisplay` with step indicators, auto-opening behavior during streaming, and a more prominent, collapsible card-style UI. (`components/chat/message/thinking-display.tsx`)
- Overhauled `ToolCallDisplay` to show tool execution status (success or failure) with clear icons and color cues, collapsible details, and improved code block formatting for arguments/results. (`components/chat/message/tool-call-display.tsx`) [[1]](diffhunk://#diff-db5bf651dc2490a205607fa4720e73c7ec1d7c9924c211d649550e4b72b57c8bL8-R9) [[2]](diffhunk://#diff-db5bf651dc2490a205607fa4720e73c7ec1d7c9924c211d649550e4b72b57c8bR40-R126)

**Styling and theme updates:**

- Added new CSS variables for success colors (`--color-success`, `--color-success-foreground`, `--success`, `--success-foreground`) to support the new status indicators. (`app/globals.css`) [[1]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R45-R46) [[2]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R67-R70) [[3]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R121-R122)

**Type exports:**

- Exported `ToolCall` and `ToolResult` types from `parse-message-metadata.ts`, making them available for use in other components. (`lib/chat/parse-message-metadata.ts`)