### PR TITLE
The `@assistant` mention functionality has been successfully restricted to ensure it can only be used at the start of a conversation and only once per chat

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -117,7 +117,24 @@ export async function POST(req: Request) {
     projectRow?.knowledgebaseId ??
     null;
 
-  const effectiveAssistantId = chatRow.assistantId || selectedAssistantId;
+  // Validation: Prevent assistant mentions if chat is already bound or has history
+  let finalSelectedAssistantId = selectedAssistantId;
+  if (selectedAssistantId) {
+    const isBoundToDifferent =
+      chatRow.assistantId && chatRow.assistantId !== selectedAssistantId;
+    const hasHistory = history.length > 0;
+
+    if (isBoundToDifferent || hasHistory) {
+      console.warn(
+        `[Chat API] Ignoring assistant mention ${selectedAssistantId} due to ${
+          isBoundToDifferent ? "bound assistant" : "existing history"
+        }`,
+      );
+      finalSelectedAssistantId = undefined;
+    }
+  }
+
+  const effectiveAssistantId = chatRow.assistantId || finalSelectedAssistantId;
 
   // Fetch assistant prompt if this chat belongs to an assistant or an assistant was mentioned
   const assistantRow = effectiveAssistantId

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -115,6 +115,9 @@ interface ChatInputProps {
   /** Assistant ID bound to the chat, if any, to disable @ mentions. */
   activeChatAssistantId?: string | null;
 
+  /** If true, allows triggering assistant mentions (@). */
+  canMentionAssistant?: boolean;
+
   /** Custom label for the submit button (defaults to "Send" icon). */
   submitLabel?: string;
 }
@@ -150,6 +153,7 @@ export function ChatInput({
   initialSelectedKbs = [],
   onKnowledgebaseChange,
   activeChatAssistantId,
+  canMentionAssistant = true,
   submitLabel,
 }: ChatInputProps) {
   const [input, setInput] = useState(initialValue);
@@ -205,6 +209,7 @@ export function ChatInput({
     activeChatAssistantId,
     initialSelectedPromptId,
     initialSelectedAssistantId,
+    canMentionAssistant,
   );
 
   useAutoExpandingTextarea(textareaRef, [input]);

--- a/components/chat/chat-ui.tsx
+++ b/components/chat/chat-ui.tsx
@@ -326,6 +326,8 @@ export function ChatUI({
                       key={msg.id}
                       message={msg}
                       isLatest={index === thread.length - 1}
+                      isFirst={index === 0}
+                      assistantId={chat?.assistantId}
                       onDelete={handleDelete}
                       onEdit={handleEdit}
                       onRegenerate={handleRegenerate}
@@ -400,6 +402,7 @@ export function ChatUI({
               onStop={stopStream}
               servers={allEnabledServers}
               activeChatAssistantId={chat?.assistantId}
+              canMentionAssistant={thread.length === 0 && !chat?.assistantId}
               initialSelectedServerIds={initialServerIds}
               initialSelectedTools={initialSelectedTools}
               initialSelectedResources={initialSelectedResources}

--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -26,6 +26,10 @@ interface MessageBubbleProps {
   message: Message;
   /** Whether this message is the last one in the current thread. */
   isLatest: boolean;
+  /** Whether this message is the first one in the thread. */
+  isFirst?: boolean;
+  /** Assistant ID bound to the chat. */
+  assistantId?: string | null;
   /** Callback to delete this message from the conversation tree. */
   onDelete: (id: string) => void;
   /** Callback to edit this message, which creates a new branch. */
@@ -74,6 +78,8 @@ interface MessageBubbleProps {
 export function MessageBubble({
   message,
   isLatest,
+  isFirst,
+  assistantId,
   onDelete,
   onEdit,
   siblings,
@@ -203,6 +209,7 @@ export function MessageBubble({
                   }}
                   onCancel={() => setIsEditing(false)}
                   servers={mcpServers.filter((s) => s.enabled)}
+                  canMentionAssistant={isFirst && !assistantId}
                 />
               ) : (
                 <MarkdownRenderer

--- a/hooks/chat/use-mention-commands.ts
+++ b/hooks/chat/use-mention-commands.ts
@@ -14,6 +14,7 @@ export function useMentionCommands(
   activeChatAssistantId?: string | null,
   initialSelectedPromptId?: string,
   initialSelectedAssistantId?: string,
+  canMentionAssistant: boolean = true,
 ) {
   const prompts = useAppStore((state) => state.prompts);
   const assistants = useAppStore((state) => state.assistants);
@@ -28,7 +29,7 @@ export function useMentionCommands(
       ? prompts.find((p) => p.id === initialSelectedPromptId) || null
       : null,
   );
-  
+
   const [selectedAssistant, setSelectedAssistant] = useState<Assistant | null>(
     initialSelectedAssistantId
       ? assistants.find((a) => a.id === initialSelectedAssistantId) || null
@@ -38,7 +39,7 @@ export function useMentionCommands(
   const filteredItems = useMemo(() => {
     if (!openTrigger) return [];
     const q = commandQuery.toLowerCase();
-    
+
     if (openTrigger === "/") {
       return prompts.filter(
         (p) =>
@@ -46,7 +47,7 @@ export function useMentionCommands(
           p.title.toLowerCase().includes(q),
       );
     }
-    
+
     if (openTrigger === "@") {
       return assistants.filter(
         (a) =>
@@ -54,7 +55,7 @@ export function useMentionCommands(
           (a.description && a.description.toLowerCase().includes(q)),
       );
     }
-    
+
     return [];
   }, [commandQuery, prompts, assistants, openTrigger]);
 
@@ -66,24 +67,31 @@ export function useMentionCommands(
       setCursorPosition(pos);
 
       const textBeforeCursor = value.slice(0, pos);
-      
+
       const lastSlashIndex = textBeforeCursor.lastIndexOf("/");
       const lastAtIndex = textBeforeCursor.lastIndexOf("@");
-      
+
       let triggerIndex = -1;
       let activeTrigger: MentionTrigger = null;
-      
+
       if (lastSlashIndex > lastAtIndex && !selectedPrompt) {
         triggerIndex = lastSlashIndex;
         activeTrigger = "/";
-      } else if (lastAtIndex > lastSlashIndex && !selectedAssistant && !activeChatAssistantId) {
+      } else if (
+        lastAtIndex > lastSlashIndex &&
+        !selectedAssistant &&
+        !activeChatAssistantId &&
+        canMentionAssistant
+      ) {
         triggerIndex = lastAtIndex;
         activeTrigger = "@";
       }
 
       if (triggerIndex !== -1) {
         const isStartOfLine = triggerIndex === 0;
-        const isAfterSpace = textBeforeCursor[triggerIndex - 1] === " " || textBeforeCursor[triggerIndex - 1] === "\n";
+        const isAfterSpace =
+          textBeforeCursor[triggerIndex - 1] === " " ||
+          textBeforeCursor[triggerIndex - 1] === "\n";
         const hasNewlineAfterTrigger = value
           .slice(triggerIndex, pos)
           .includes("\n");
@@ -99,13 +107,19 @@ export function useMentionCommands(
         setOpenTrigger(null);
       }
     },
-    [setInput, selectedPrompt, selectedAssistant, activeChatAssistantId],
+    [
+      setInput,
+      selectedPrompt,
+      selectedAssistant,
+      activeChatAssistantId,
+      canMentionAssistant,
+    ],
   );
 
   const handleSelect = useCallback(
     (item: Prompt | Assistant) => {
       if (!openTrigger) return;
-      
+
       const textBeforeCursor = input.slice(0, cursorPosition);
       const triggerIndex = textBeforeCursor.lastIndexOf(openTrigger);
 
@@ -114,22 +128,19 @@ export function useMentionCommands(
           input.slice(0, triggerIndex) + input.slice(cursorPosition);
 
         setInput(newInput);
-        
+
         if (openTrigger === "/") {
           setSelectedPrompt(item as Prompt);
         } else if (openTrigger === "@") {
           setSelectedAssistant(item as Assistant);
         }
-        
+
         setOpenTrigger(null);
 
         setTimeout(() => {
           if (textareaRef.current) {
             textareaRef.current.focus();
-            textareaRef.current.setSelectionRange(
-              triggerIndex,
-              triggerIndex,
-            );
+            textareaRef.current.setSelectionRange(triggerIndex, triggerIndex);
           }
         }, 0);
       }
@@ -149,8 +160,7 @@ export function useMentionCommands(
       if (e.key === "ArrowUp") {
         e.preventDefault();
         setSelectedIndex(
-          (prev) =>
-            (prev - 1 + filteredItems.length) % filteredItems.length,
+          (prev) => (prev - 1 + filteredItems.length) % filteredItems.length,
         );
         return true;
       }


### PR DESCRIPTION
1.  **Strict Selection Rules**:
    *   **"Only at Start"**: The `@assistant` trigger is now disabled if the chat already has messages or is being continued from a previous message branch.
    *   **"One Assistant Per Chat"**: Once an assistant is mentioned, additional `@assistant` commands are prevented in `ChatInput`.
    *   **"Bound Assistant Sync"**: If a chat is already pre-bound to an assistant, mentions of other assistants are blocked.

2.  **Server-Side Protection**:
    *   Modified route.ts to perform fail-safe checks. Even if a user attempts to bypass the UI constraints and sends an assistant ID via the API, the server will ignore it if the chat is already bound or has an existing message history.

3.  **Branch-Aware Logic**:
    *   The "first message" check is correctly tied to the current thread version (branching). This ensures that if you start a new branch from the very beginning of a conversation, you can still mention an assistant for that fresh thread.

4.  **Integrated with Message Editing**:
    *   Editing the first message of a chat (when not bound to an assistant) still allows you to manage the assistant mention, while editing subsequent messages correctly hides the assistant picker.