### PR TITLE
feat: Implement user settings management with global system prompt configuration

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -16,6 +16,7 @@ import type { FileBridgeResult } from "@/types/file-bridge-result";
 import { assembleModelMessages } from "@/lib/chat/assemble-model-messages";
 import { buildSystemPrompt } from "@/lib/chat/build-system-prompt";
 import { registerMcpTools } from "@/lib/chat/register-mcp-tools";
+import { getUserSettings } from "@/lib/actions/user-settings/get-user-settings";
 import { logger } from "@/lib/logger";
 
 export const maxDuration = 60;
@@ -55,6 +56,10 @@ const openrouter = createOpenAI({
 export async function POST(req: Request) {
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) return new Response("Unauthorized", { status: 401 });
+
+  // Fetch user settings for global prompt
+  const userSettings = await getUserSettings().catch(() => null);
+  const globalSystemPrompt = userSettings?.globalSystemPrompt;
 
   const body = await req.json();
   const parsed = chatRequestSchema.safeParse(body);
@@ -247,6 +252,7 @@ export async function POST(req: Request) {
   const processedMessages = assembleModelMessages(history, bridge);
 
   const systemMessages = buildSystemPrompt(
+    globalSystemPrompt,
     projectRow?.globalPrompt,
     assistantRow?.prompt,
     bridge,

--- a/app/settings/app/page.tsx
+++ b/app/settings/app/page.tsx
@@ -1,42 +1,21 @@
-"use client";
-
-import { Settings } from "lucide-react";
+import { getUserSettings } from "@/lib/actions/user-settings/get-user-settings";
+import { GlobalPromptForm } from "@/components/settings/global-prompt-form";
 import { PageHeader } from "@/components/page-header";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { requireSession } from "@/lib/actions/require-session";
+import { Settings2 } from "lucide-react";
 
-/**
- * App settings page — client component for application-wide preferences and configuration.
- * Currently a placeholder for future global settings.
- * Directs users to MCP tools section for current tool/server configuration.
- */
-export default function AppSettingsPage() {
+export default async function SettingsPage() {
+  await requireSession();
+  const settings = await getUserSettings();
+
   return (
     <div className="space-y-6">
       <PageHeader
-        icon={<Settings className="h-8 w-8 text-primary" />}
-        title="App Settings"
+        icon={<Settings2 className="size-8" />}
+        title="General Settings"
         description="Manage your application-wide preferences and configurations."
       />
-
-      <Card>
-        <CardHeader>
-          <CardTitle>General Settings</CardTitle>
-          <CardDescription>
-            Additional settings will be available here in the future.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            Currently, you can manage your MCP tools in the Tools section.
-          </p>
-        </CardContent>
-      </Card>
+      <GlobalPromptForm initialSettings={settings ?? {}} />
     </div>
   );
 }

--- a/components/settings/global-prompt-form.tsx
+++ b/components/settings/global-prompt-form.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  userSettingsSchema,
+  type UserSettingsFormData as UserSettings,
+} from "@/schemas/user-settings";
+import { updateUserSettings } from "@/lib/actions/user-settings/update-user-settings";
+import { useAutoExpandingTextarea } from "@/hooks/use-auto-expanding-textarea";
+import { useRef } from "react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent } from "@/components/ui/card";
+import { ActionButton } from "@/components/ui/action-button";
+
+interface GlobalPromptFormProps {
+  initialSettings: Partial<UserSettings>;
+}
+
+export function GlobalPromptForm({ initialSettings }: GlobalPromptFormProps) {
+  const form = useForm<UserSettings>({
+    resolver: zodResolver(userSettingsSchema),
+    defaultValues: {
+      globalSystemPrompt: initialSettings.globalSystemPrompt ?? "",
+    },
+  });
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useAutoExpandingTextarea(
+    textareaRef,
+    [form.watch("globalSystemPrompt")],
+    600,
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-start">
+        <div>
+          <h3 className="text-lg font-medium">Global System Prompt</h3>
+          <p className="text-sm text-muted-foreground">
+            This prompt will be prepended to all AI requests, providing a
+            consistent base instruction set.
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6">
+          <Form {...form}>
+            <form className="space-y-4">
+              <FormField
+                control={form.control}
+                name="globalSystemPrompt"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        value={field.value ?? ""}
+                        ref={(e) => {
+                          field.ref(e);
+                          (textareaRef as any).current = e;
+                        }}
+                        placeholder="Enter your global system prompt..."
+                        className="min-h-[100px] resize-none"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end">
+                <ActionButton
+                  type="submit"
+                  action={async () => {
+                    try {
+                      const values = form.getValues();
+                      await updateUserSettings(values);
+                      return {
+                        error: false,
+                        message: "Settings updated successfully",
+                      };
+                    } catch (error: any) {
+                      return {
+                        error: true,
+                        message: error?.message || "Failed to update settings",
+                      };
+                    }
+                  }}
+                >
+                  Save Changes
+                </ActionButton>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -16,3 +16,4 @@ export * from "./schemas/transform-agent-schema";
 export * from "./schemas/knowledgebase-schema";
 export * from "./schemas/kb-document-schema";
 export * from "./schemas/kb-chunk-schema";
+export * from "./schemas/user-settings-schema";

--- a/drizzle/schemas/user-settings-schema.ts
+++ b/drizzle/schemas/user-settings-schema.ts
@@ -1,0 +1,29 @@
+import { pgTable, text, timestamp, index } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema";
+
+/**
+ * Stores application-wide user preferences and settings.
+ * One-to-one with user (CASCADE DELETE); globalSystemPrompt prepends all AI interactions.
+ * Enables users to define a baseline system instruction that applies across all projects and assistants.
+ *
+ * @author Maruf Bepary
+ */
+export const userSettings = pgTable(
+  "user_settings",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .unique()
+      .references(() => user.id, { onDelete: "cascade" }),
+    globalSystemPrompt: text("global_system_prompt"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [index("user_settings_user_id_idx").on(table.userId)],
+);

--- a/lib/actions/user-settings/get-user-settings.ts
+++ b/lib/actions/user-settings/get-user-settings.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { requireSession } from "@/lib/actions/require-session";
+import { db } from "@/drizzle/db";
+import { userSettings } from "@/drizzle/schema";
+import { eq } from "drizzle-orm";
+import type { UserSettingsRow } from "@/types/user-settings-row";
+
+/**
+ * Fetches application-wide settings for the authenticated user.
+ * Returns null if no settings have been initialized for the user yet.
+ * Use this to retrieve the global system prompt or other user-wide preferences.
+ * 
+ * @returns The user settings record or null if not found
+ * @throws {Error} "Unauthorized" if no valid session is found
+ * @author Maruf Bepary
+ */
+export async function getUserSettings(): Promise<UserSettingsRow | null> {
+  const session = await requireSession();
+
+  const [row] = await db
+    .select()
+    .from(userSettings)
+    .where(eq(userSettings.userId, session.user.id));
+
+  return row || null;
+}

--- a/lib/actions/user-settings/update-user-settings.ts
+++ b/lib/actions/user-settings/update-user-settings.ts
@@ -1,0 +1,55 @@
+"use server";
+
+import { requireSession } from "@/lib/actions/require-session";
+import { db } from "@/drizzle/db";
+import { userSettings } from "@/drizzle/schema";
+import { userSettingsSchema } from "@/schemas/user-settings";
+import { revalidatePath } from "next/cache";
+import type { UserSettingsRow } from "@/types/user-settings-row";
+import { logger } from "@/lib/logger";
+import { z } from "zod";
+
+/**
+ * Updates or initializes application-wide settings for the authenticated user.
+ * Specifically manages global preferences such as the global system prompt.
+ * Uses an upsert pattern based on userId to ensure only one setting row exists 
+per user.
+ * 
+ * @param data - Setting values validated against userSettingsSchema
+ * @returns The updated or newly created user settings record
+ * @throws {Error} "Unauthorized" if no session exists
+ * @throws {ZodError} If input data fails validation
+ * @author Maruf Bepary
+ */
+export async function updateUserSettings(
+  data: z.infer<typeof userSettingsSchema>,
+): Promise<UserSettingsRow> {
+  const session = await requireSession();
+
+  // Validate input
+  const validated = userSettingsSchema.parse(data);
+
+  const [row] = await db
+    .insert(userSettings)
+    .values({
+      userId: session.user.id,
+      globalSystemPrompt: validated.globalSystemPrompt ?? null,
+    })
+    .onConflictDoUpdate({
+      target: userSettings.userId,
+      set: {
+        globalSystemPrompt: validated.globalSystemPrompt ?? null,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+
+  logger.audit("Update User Settings", {
+    userId: session.user.id,
+    settingsId: row.id,
+  });
+
+  revalidatePath("/settings/app");
+
+  return row;
+}

--- a/lib/chat/build-system-prompt.ts
+++ b/lib/chat/build-system-prompt.ts
@@ -3,12 +3,17 @@ import type { FileBridgeResult } from "@/types/file-bridge-result";
 import { PROMPTS } from "@/constants/prompts";
 
 export function buildSystemPrompt(
+  globalPrompt: string | null | undefined,
   projectPrompt: string | null | undefined,
   assistantPrompt: string | null | undefined,
   bridge: FileBridgeResult | null,
   hasKnowledgeBase: boolean,
 ): ModelMessage[] {
   const systemParts: string[] = [];
+
+  if (globalPrompt?.trim()) {
+    systemParts.push(globalPrompt.trim());
+  }
 
   if (projectPrompt?.trim()) {
     systemParts.push(projectPrompt.trim());

--- a/schemas/user-settings.ts
+++ b/schemas/user-settings.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * Validates application-wide user preferences including global system prompts.
+ * globalSystemPrompt is optional and capped at 5000 characters to ensure token efficiency.
+ * Use with {@link lib/actions/user-settings/update-user-settings.ts} to persist user-wide AI instructions.
+ *
+ * @author Maruf Bepary
+ */
+export const userSettingsSchema = z.object({
+  globalSystemPrompt: z
+    .string()
+    .max(5000, "Prompt must be under 5000 characters")
+    .optional()
+    .nullable(),
+});
+
+/**
+ * Type-safe interface for user settings forms and state.
+ * Derived from userSettingsSchema for consistency across UI components and server actions.
+ */
+export type UserSettingsFormData = z.infer<typeof userSettingsSchema>;

--- a/types/user-settings-row.ts
+++ b/types/user-settings-row.ts
@@ -1,0 +1,11 @@
+import { type InferSelectModel } from "drizzle-orm";
+import { userSettings } from "../drizzle/schema";
+
+/**
+ * Database representation of user-wide settings (e.g., global system prompt) from the drizzle schema.
+ * One-to-one with user; globalSystemPrompt prepends all AI interactions.
+ * 
+ * @see {@link ../drizzle/schemas/user-settings-schema.ts} for database definition
+ * @author Maruf Bepary
+ */
+export type UserSettingsRow = InferSelectModel<typeof userSettings>;


### PR DESCRIPTION

This pull request introduces support for application-wide user settings, focusing on a new "global system prompt" feature. This allows users to define a baseline instruction that will be prepended to all AI interactions, regardless of project or assistant context. The implementation includes backend schema and API changes, server actions for fetching and updating settings, and a new UI for managing the global prompt.

**Global System Prompt Feature**

* Added a new `user_settings` table to store per-user global preferences, including a `globalSystemPrompt` field that is prepended to all AI requests.
* Implemented the `getUserSettings` and `updateUserSettings` server actions for fetching and updating user settings, with appropriate validation and upsert logic. [[1]](diffhunk://#diff-8d479f82dd6a7f848336c88f88ce841756c83cc077f92192f91608df54e1cc54R1-R27) [[2]](diffhunk://#diff-e8f71972e9551f20a68202c9073b6af387b7a237cbcf909b0dedd5f6623fcf1dR1-R55)
* Updated the chat API route and the `buildSystemPrompt` function to include the user's global system prompt in all AI interactions. [[1]](diffhunk://#diff-801bec1474c7c5e37b836db21695f406a724ef597a38129f6a6bb4959e6b4135R19) [[2]](diffhunk://#diff-801bec1474c7c5e37b836db21695f406a724ef597a38129f6a6bb4959e6b4135R60-R63) [[3]](diffhunk://#diff-801bec1474c7c5e37b836db21695f406a724ef597a38129f6a6bb4959e6b4135R255) [[4]](diffhunk://#diff-88d765fd635ee5e48a1a991672463ad87466259d2aae567304a84c324a60bb16R6-R17)

**Settings UI Improvements**

* Replaced the placeholder app settings page with a new server component that displays and allows editing of the global system prompt via the `GlobalPromptForm` component. [[1]](diffhunk://#diff-b60f1164a27c633ff321fd46806b71795ed913952d87f2bbdf3d3593ec2a3617L1-R18) [[2]](diffhunk://#diff-e64c524ed2ead49f6512d43c5db5bef0585302bc0cec0213b386307987fe34acR1-R108)

**Validation and Types**

* Added a Zod schema for user settings validation and a type-safe interface for form data.
* Introduced a database row type for user settings for use across the codebase.
* Registered the new schema in the Drizzle ORM exports.

These changes lay the foundation for user-customizable AI behavior across the application by enabling a persistent, global system prompt.