### PR TITLE
Removed check for tools

### DIFF
--- a/components/chat/attachments-menu.tsx
+++ b/components/chat/attachments-menu.tsx
@@ -13,7 +13,11 @@ interface AttachmentsMenuProps {
   fileInputRef: React.RefObject<HTMLInputElement | null>;
   selectedTools: Set<string>;
   onToggleTool: (serverId: string, toolName: string) => void;
-  onBulkSelect: (serverId: string, toolNames: string[], select: boolean) => void;
+  onBulkSelect: (
+    serverId: string,
+    toolNames: string[],
+    select: boolean,
+  ) => void;
   knowledgebases?: Knowledgebase[];
   selectedKbs: Set<string>;
   onToggleKb: (id: string) => void;
@@ -66,7 +70,7 @@ export const AttachmentsMenu = ({
           variant="ghost"
           size="sm"
           className="justify-start w-full"
-          disabled={!servers || servers.length === 0 || !supportsTools}
+          disabled={!servers || !supportsTools}
         >
           <Wrench className="mr-2 h-4 w-4" />
           {supportsTools ? "Select Tools" : "Tools Unsupported"}

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -155,7 +155,8 @@ export function ChatInput({
   submitLabel,
 }: ChatInputProps) {
   const [input, setInput] = useState(initialValue);
-  const { models: chatModels } = useUserModels("chat");
+  const { models: chatModels, isLoading: isModelsLoading } =
+    useUserModels("chat");
   const [modelId, setModelId] = useState<string>(initialModelId ?? "");
   const [attachments, setAttachments] =
     useState<Attachment[]>(initialAttachments);
@@ -194,10 +195,12 @@ export function ChatInput({
     [selectedModelObj],
   );
 
-  const supportsTools = useMemo(
-    () => selectedModelObj?.capTools ?? false,
-    [selectedModelObj],
-  );
+  const supportsTools = useMemo(() => {
+    // Prevent flickering: assume tools supported while models are loading
+    // if we have a modelId set (likely from persistent state)
+    if (isModelsLoading && modelId && !selectedModelObj) return true;
+    return selectedModelObj?.capTools ?? false;
+  }, [selectedModelObj, isModelsLoading, modelId]);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
- Even if no MCP tools are configured, tools are always available
- This is because internal tools are always available